### PR TITLE
Feature/webhookfix

### DIFF
--- a/src/main/java/com/heb/togglr/api/TogglrApiApplication.java
+++ b/src/main/java/com/heb/togglr/api/TogglrApiApplication.java
@@ -3,10 +3,12 @@ package com.heb.togglr.api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 
 @SpringBootApplication
 @ComponentScan(basePackages = {"com.heb.togglr"})
+@EnableAsync
 public class TogglrApiApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/heb/togglr/api/handlers/UpdateEventHandlers.java
+++ b/src/main/java/com/heb/togglr/api/handlers/UpdateEventHandlers.java
@@ -6,6 +6,7 @@ import org.springframework.data.rest.core.annotation.HandleAfterCreate;
 import org.springframework.data.rest.core.annotation.HandleAfterSave;
 import org.springframework.data.rest.core.annotation.HandleBeforeDelete;
 import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -26,6 +27,7 @@ public class UpdateEventHandlers {
     }
 
     @HandleAfterSave
+    @Async
     public void handleFeatureSave(FeatureEntity fe) {
         try {
             AppEntity appEntity = fe.getAppByAppId();
@@ -38,6 +40,7 @@ public class UpdateEventHandlers {
     }
 
     @HandleAfterSave
+    @Async
     public void handleConfigSave(ConfigsEntity ce) {
         try {
             AppEntity appEntity = ce.getAppByAppId();
@@ -50,6 +53,7 @@ public class UpdateEventHandlers {
     }
 
     @HandleAfterCreate
+    @Async
     public void handleFeatureCreate(FeatureEntity fe) {
         try {
             AppEntity appEntity = fe.getAppByAppId();
@@ -62,6 +66,7 @@ public class UpdateEventHandlers {
     }
 
     @HandleAfterCreate
+    @Async
     public void handleConfigCreate(ConfigsEntity ce) {
         try {
             AppEntity appEntity = ce.getAppByAppId();
@@ -74,7 +79,8 @@ public class UpdateEventHandlers {
     }
 
     @HandleBeforeDelete
-    public void handleFeaturDelete(FeatureEntity fe) {
+    @Async
+    public void handleFeatureDelete(FeatureEntity fe) {
         try {
             AppEntity appEntity = fe.getAppByAppId();
 
@@ -86,6 +92,7 @@ public class UpdateEventHandlers {
     }
 
     @HandleBeforeDelete
+    @Async
     public void handleConfigDelete(ConfigsEntity ce) {
         try {
             AppEntity appEntity = ce.getAppByAppId();
@@ -97,7 +104,7 @@ public class UpdateEventHandlers {
         }
     }
 
-    private void callWebhook(String webhookUrl){
+    public void callWebhook(String webhookUrl){
         if(webhookUrl != null) {
             logger.debug("Calling webhook, triggered by update.");
             logger.trace("Webhook URL: " + webhookUrl);
@@ -107,6 +114,7 @@ public class UpdateEventHandlers {
                     logger.debug("Webhook update successful.");
                 }
             }catch (RestClientException e){
+                logger.debug("An exception happened when calling Webhook. See error log for details.");
                 logger.error(e.getMessage());
             }
         }

--- a/src/main/java/com/heb/togglr/api/handlers/UpdateEventHandlers.java
+++ b/src/main/java/com/heb/togglr/api/handlers/UpdateEventHandlers.java
@@ -104,7 +104,7 @@ public class UpdateEventHandlers {
         }
     }
 
-    public void callWebhook(String webhookUrl){
+    private void callWebhook(String webhookUrl){
         if(webhookUrl != null) {
             logger.debug("Calling webhook, triggered by update.");
             logger.trace("Webhook URL: " + webhookUrl);
@@ -114,7 +114,7 @@ public class UpdateEventHandlers {
                     logger.debug("Webhook update successful.");
                 }
             }catch (RestClientException e){
-                logger.debug("An exception happened when calling Webhook. See error log for details.");
+                logger.debug("An exception happened inside callWebhook. See error log for details.");
                 logger.error(e.getMessage());
             }
         }


### PR DESCRIPTION
This prevents an API call from being stuck on 'pending' when a feature is toggled on/off. 

At first we had added an @Async to the callWebhook function, but after testing it some more today I noticed that didn't make a difference. Instead, putting @Async on the event handlers got the desired results specified in JIRA TCK-6. 

To test, I used a separate Spring Boot application that did a thread.sleep() for 3 minutes inside an endpoint. I can see Togglr-API react to it (used a log to test) when the response comes back from the other app after the sleep and Togglr's UI request is no longer hanging for X minutes. Since all those event handlers have a callWebhook reference, I put @Async over all of them. Can change if needed. [This is for github issue 14](https://github.com/HEB/togglr/issues/14)